### PR TITLE
share button

### DIFF
--- a/administrator/components/com_content/views/article/tmpl/modal.php
+++ b/administrator/components/com_content/views/article/tmpl/modal.php
@@ -86,6 +86,7 @@ JFactory::getDocument()->addScriptDeclaration('
 	<button class="btn btn-primary" type="button" onclick="Joomla.submitbutton('article.apply');"><?php echo JText::_('JTOOLBAR_APPLY') ?></button>
 	<button class="btn btn-primary" type="button" onclick="Joomla.submitbutton('article.save');"><?php echo JText::_('JTOOLBAR_SAVE') ?></button>
 	<button class="btn" type="button" onclick="Joomla.submitbutton('article.cancel');"><?php echo JText::_('JCANCEL') ?></button>
+	<button class="btn" type="button" onclick="Joomla.submitbutton('article.share');"><?php echo JText::_('JSHARE') ?></button>
 </div>
 
 <div class="clearfix"> </div>

--- a/administrator/components/com_content/views/article/tmpl/modal.php
+++ b/administrator/components/com_content/views/article/tmpl/modal.php
@@ -86,7 +86,6 @@ JFactory::getDocument()->addScriptDeclaration('
 	<button class="btn btn-primary" type="button" onclick="Joomla.submitbutton('article.apply');"><?php echo JText::_('JTOOLBAR_APPLY') ?></button>
 	<button class="btn btn-primary" type="button" onclick="Joomla.submitbutton('article.save');"><?php echo JText::_('JTOOLBAR_SAVE') ?></button>
 	<button class="btn" type="button" onclick="Joomla.submitbutton('article.cancel');"><?php echo JText::_('JCANCEL') ?></button>
-	<button class="btn" type="button" onclick="Joomla.submitbutton('article.share');"><?php echo JText::_('JSHARE') ?></button>
 </div>
 
 <div class="clearfix"> </div>

--- a/administrator/components/com_content/views/article/view.html.php
+++ b/administrator/components/com_content/views/article/view.html.php
@@ -98,7 +98,7 @@ class ContentViewArticle extends JViewLegacy
 			JToolbarHelper::save('article.save');
 			JToolbarHelper::save2new('article.save2new');
 			JToolbarHelper::cancel('article.cancel');
-			JToolbarHelper::cancel('article.cancel');
+			
 		}
 		else
 		{
@@ -128,6 +128,7 @@ class ContentViewArticle extends JViewLegacy
 			if ($this->state->params->get('save_history', 0) && $canDo->get('core.edit'))
 			{
 				JToolbarHelper::versions('com_content.article', $this->item->id);
+				JToolbarHelper::custom('article.shareDraft', 'share.png', 'share.png','Share', false);
 			}
 
 			JToolbarHelper::cancel('article.cancel', 'JTOOLBAR_CLOSE');

--- a/administrator/components/com_content/views/article/view.html.php
+++ b/administrator/components/com_content/views/article/view.html.php
@@ -98,6 +98,7 @@ class ContentViewArticle extends JViewLegacy
 			JToolbarHelper::save('article.save');
 			JToolbarHelper::save2new('article.save2new');
 			JToolbarHelper::cancel('article.cancel');
+			JToolbarHelper::cancel('article.cancel');
 		}
 		else
 		{


### PR DESCRIPTION
In add article page, an extra button has been added in the sub toolbar called as Share. This button is visible only when the article is saved.
